### PR TITLE
Avoid multi z2m version messages

### DIFF
--- a/core/class/z2m.class.php
+++ b/core/class/z2m.class.php
@@ -142,15 +142,17 @@ class z2m extends eqLogic {
 		if ($package['version'] !='') {
 			$releaseVersion = file_get_contents('https://raw.githubusercontent.com/Koenkk/zigbee2mqtt/master/package.json');
 				if ($releaseVersion !== false) {
-				$releaseVersion = json_decode($releaseVersion, true);
-				if (is_array($releaseVersion) && json_last_error() == '' && isset($releaseVersion['version']) && $package['version'] !== $releaseVersion['version']) {
-					log::add('z2m', 'info', 'Nouvelle version de Zigbee2MQTT disponible : '.$releaseVersion['version'].' (Relancez les dépendances du plugin Jeezigbee pour effectuer la mise à jour)');
-					message::add('z2m', __('Nouvelle version de Zigbee2MQTT disponible' ,__FILE__) . ' : '.$releaseVersion['version'].' (Relancez les dépendances du plugin Jeezigbee pour effectuer la mise à jour)', null, null);
+					$releaseVersion = json_decode($releaseVersion, true);
+					$lastZigbee2mqttVersion = config::byKey('lastZigbee2mqttVersion', 'z2m');
+					if (is_array($releaseVersion) && json_last_error() == '' && isset($releaseVersion['version']) && $package['version'] !== $releaseVersion['version'] && $lastZigbee2mqttVersion != $releaseVersion['version']) {
+                  				config::save('lastZigbee2mqttVersion', $package['version'], 'z2m');
+						log::add('z2m', 'info', 'Nouvelle version de Zigbee2MQTT disponible : '.$releaseVersion['version'].' (Relancez les dépendances du plugin Jeezigbee pour effectuer la mise à jour)');
+						message::add('z2m', __('Nouvelle version de Zigbee2MQTT disponible' ,__FILE__) . ' : '.$releaseVersion['version'].' (Relancez les dépendances du plugin Jeezigbee pour effectuer la mise à jour)', null, null);
+					}
 				}
 			}
 		}
-	}
-  }
+	  }
   
   public static function cron() {
     foreach (eqLogic::byType('z2m', true) as $eqLogic) {


### PR DESCRIPTION
## Description
Evite d'envoyer un message signalant la sortie d'une nouvelle version de zigbee2mqtt lors du dailycron si celle ci a déjà été signalée


### Suggested changelog entry
Suppression du doublon de notification sur les versions de zigbee2mqtt


### Related issues/external references

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
