### PR TITLE
Ajout de l'option No Converter pour les commandes de type info

### DIFF
--- a/core/class/z2m.class.php
+++ b/core/class/z2m.class.php
@@ -1101,6 +1101,9 @@ class z2m extends eqLogic {
           if(in_array($logicalId,array('linkquality','last_seen'))){
             	continue; 
           }
+	  if ($cmd->getConfiguration('noConverter', '0') == '1') {  // no Converter
+	 	continue; 
+          }
           $datas = array($logicalId => '');
           log::add('z2m','debug','[execute] '.z2m::getRootTopic() . '/' . z2m::convert_from_addr(explode('|', $this->getLogicalId())[0]) . '/get => '.json_encode($datas));
           mqtt2::publish(z2m::getRootTopic() . '/' . z2m::convert_from_addr(explode('|', $this->getLogicalId())[0]) . '/get', json_encode($datas));

--- a/desktop/js/z2m.js
+++ b/desktop/js/z2m.js
@@ -200,7 +200,7 @@ tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAtt
 tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr" data-l1key="display" data-l2key="invertBinary"/>{{Inverser}}</label></span> ';
 // No Converter
 if (init(_cmd.type) == "info") {
-  tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="configuration" data-l2key="noConverter"/>{{No Converter}}</label></span> ';
+  tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="configuration" data-l2key="noConverter" title="{{Activer pour ne pas mettre à jour lors d\'un Refresh de l\'équipement (utile lorsqu\'il n\'existe pas de converter pour le champ)}}" />{{No Converter}} </label></span> ';
 }
 tr += '</td>';
 tr += '<td>';

--- a/desktop/js/z2m.js
+++ b/desktop/js/z2m.js
@@ -198,6 +198,10 @@ tr += '<input class="tooltips cmdAttr form-control input-sm" data-l1key="configu
 tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" checked/>{{Afficher}}</label></span> ';
 tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span> ';
 tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr" data-l1key="display" data-l2key="invertBinary"/>{{Inverser}}</label></span> ';
+// No Converter
+if (init(_cmd.type) == "info") {
+  tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="configuration" data-l2key="noConverter"/>{{No Converter}}</label></span> ';
+}
 tr += '</td>';
 tr += '<td>';
 tr += '<span class="cmdAttr" data-l1key="htmlstate"></span>'; 


### PR DESCRIPTION
## Description
<!--


-->
La commande Refresh demande une mise à jour à Z2M pour toutes les commandes info à l'exception de 'linkquality' et 'last_seen' (voir fonction refreshValue())

Dans le cas où il n'y a pas de converter défini dans Z2M pour le device concerné, on reçoit une erreur par exemple : 

2025-02-02 17:17:11z2m: No converter available for 'battery' ("")

A priori, il n'y a pas de moyen de savoir si il y a un converter ou pas pour une commande donnée.

Le PR permet d'indiquer pour chaque commande info si il y a converter ou pas; en fonction de cet indicateur, la fonction refreshValue() fera une demande de récupération de la donnée à Z2M ou pas.

### Suggested changelog entry

- Modification de z2m.js afin d'ajouter l'indicateur noConverter pour les commandes de type info
- Modification dans z2m.class.php de la fonction refreshValue afin de ne pas demander la mise à jour des champs pour lesquels l'indicateur noConverter est activé


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [X] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
