### PR TITLE
add additionnal dependency check method

### DIFF
--- a/core/class/z2m.class.php
+++ b/core/class/z2m.class.php
@@ -184,6 +184,16 @@ class z2m extends eqLogic {
     return false;
   }
 
+  public static function additionnalDependancyCheck() {
+    $return = array();
+    if (config::byKey('z2m::mode', __CLASS__) === 'local') {
+      if (!file_exists(__DIR__ . '/../../resources/zigbee2mqtt/node_modules')) {
+        $return['state'] = 'nok';
+      }
+    }
+    return $return;
+  }
+
   public static function deamon_info() {
     $return = array();
     $return['log'] = __CLASS__;


### PR DESCRIPTION
This adds the `additionnalDependancyCheck` method to the Z2M plugin.

The plugin previously had no additional dependency check.  
This new method introduces a simple validation ensuring that, when running in *local* mode, the required `node_modules` directory for Zigbee2MQTT exists.

Same idea as in jeedom/plugin-zwavejs#35, for consistency across plugins.